### PR TITLE
Added a new deploy version and update lambda alias build step

### DIFF
--- a/src/main/java/com/xti/jenkins/plugin/awslambda/AWSLambdaDescriptor.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/AWSLambdaDescriptor.java
@@ -43,4 +43,22 @@ public abstract class AWSLambdaDescriptor<T extends Describable<T>> extends Desc
             return FormValidation.ok();
         }
     }
+
+    //functionARN field
+    public FormValidation doCheckFunctionARN(@QueryParameter String value) {
+        if(StringUtils.isEmpty(value)){
+            return FormValidation.error("Please fill in AWS Lambda function ARN.");
+        } else {
+            return FormValidation.ok();
+        }
+    }
+
+    //functionAlias field
+    public FormValidation doCheckFunctionAlias(@QueryParameter String value) {
+        if(StringUtils.isEmpty(value)){
+            return FormValidation.error("Please fill in AWS Lambda alias name.");
+        } else {
+            return FormValidation.ok();
+        }
+    }
 }

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/callable/PublishCallable.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/callable/PublishCallable.java
@@ -1,0 +1,49 @@
+package com.xti.jenkins.plugin.awslambda.callable;
+
+import com.xti.jenkins.plugin.awslambda.publish.LambdaPublishServiceResponse;
+import com.xti.jenkins.plugin.awslambda.publish.LambdaPublisher;
+import com.xti.jenkins.plugin.awslambda.publish.PublishConfig;
+import com.xti.jenkins.plugin.awslambda.service.JenkinsLogger;
+import com.xti.jenkins.plugin.awslambda.service.LambdaPublishService;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.model.TaskListener;
+import hudson.remoting.Callable;
+import org.jenkinsci.remoting.RoleChecker;
+
+import java.io.IOException;
+
+/**
+ * Project: aws-lambda
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class PublishCallable implements Callable<LambdaPublishServiceResponse, RuntimeException> {
+
+    private TaskListener listener;
+    private PublishConfig publishConfig;
+    private LambdaClientConfig clientConfig;
+
+    public PublishCallable(TaskListener listener, PublishConfig publishConfig, LambdaClientConfig lambdaClientConfig) {
+        this.listener = listener;
+        this.publishConfig = publishConfig;
+        this.clientConfig = lambdaClientConfig;
+    }
+
+    @Override
+    public LambdaPublishServiceResponse call() throws RuntimeException {
+
+        JenkinsLogger logger = new JenkinsLogger(listener.getLogger());
+        LambdaPublishService service = new LambdaPublishService(clientConfig.getClient(), logger);
+
+        try {
+            LambdaPublisher publishPublisher = new LambdaPublisher(service, logger);
+            return publishPublisher.publish(publishConfig);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void checkRoles(RoleChecker roleChecker) throws SecurityException {
+        //ignore for now
+    }
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishAction.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishAction.java
@@ -1,0 +1,46 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import hudson.model.ProminentProjectAction;
+
+/**
+ * Project: aws-lambda
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class LambdaPublishAction implements ProminentProjectAction{
+    private static final String URL_NAME = "console";
+
+    private final String iconFileName;
+    private final String bigIconFileName;
+    private final String displayName;
+
+    public LambdaPublishAction(String functionVersion, String functionAlias, Boolean success) {
+        if(success){
+            iconFileName = "/plugin/aws-lambda/images/Lambda_24.png";
+            bigIconFileName = "/plugin/aws-lambda/images/Lambda_48.png";
+            displayName = "Lambda alias " + functionAlias + " points to version " + functionVersion;
+        }else {
+            iconFileName = "/plugin/aws-lambda/images/Lambda_24_grey.png";
+            bigIconFileName = "/plugin/aws-lambda/images/Lambda_48_grey.png";
+            displayName = "Unable to point alias " + functionAlias + " to version " + functionVersion;
+        }
+    }
+
+    @Override
+    public String getIconFileName() {
+        return iconFileName;
+    }
+
+    public String getBigIconFileName() {
+        return bigIconFileName;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getUrlName() {
+        return URL_NAME;
+    }
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStep.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStep.java
@@ -1,0 +1,111 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.xti.jenkins.plugin.awslambda.callable.PublishCallable;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Builder;
+import jenkins.tasks.SimpleBuildStep;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * Project: aws-lambda
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class LambdaPublishBuildStep extends Builder implements SimpleBuildStep {
+    private LambdaPublishBuildStepVariables lambdaPublishBuildStepVariables;
+
+    @DataBoundConstructor
+    public LambdaPublishBuildStep(LambdaPublishBuildStepVariables lambdaPublishBuildStepVariables) {
+        this.lambdaPublishBuildStepVariables = lambdaPublishBuildStepVariables;
+    }
+
+    public LambdaPublishBuildStepVariables getLambdaPublishBuildStepVariables() {
+        return this.lambdaPublishBuildStepVariables;
+    }
+
+    public void setLambdaPublishBuildStepVariables(LambdaPublishBuildStepVariables lambdaPublishBuildStepVariables){
+        this.lambdaPublishBuildStepVariables = lambdaPublishBuildStepVariables;
+    }
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        perform(lambdaPublishBuildStepVariables, run, launcher, listener);
+    }
+
+    public void perform(LambdaPublishBuildStepVariables lambdaPublishBuildStepVariables, Run<?, ?> run, Launcher launcher, TaskListener listener) {
+        try {
+            LambdaPublishBuildStepVariables executionVariables = lambdaPublishBuildStepVariables.getClone();
+            executionVariables.expandVariables(run.getEnvironment(listener));
+            PublishConfig publishConfig = executionVariables.getPublishConfig();
+            LambdaClientConfig clientConfig = executionVariables.getLambdaClientConfig();
+
+            PublishCallable publishCallable = new PublishCallable(listener, publishConfig, clientConfig);
+
+            LambdaPublishServiceResponse lambdaSuccess = launcher.getChannel().call(publishCallable);
+
+            if(!lambdaSuccess.getSuccess()){
+                run.setResult(Result.FAILURE);
+            }
+
+            run.addAction(new LambdaPublishAction(lambdaSuccess.getFunctionVersion(), lambdaSuccess.getFunctionAlias(), lambdaSuccess.getSuccess()));
+        } catch(Exception exc) {
+            throw new RuntimeException(exc);
+        }
+    }
+
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    // Overridden for better type safety.
+    // If your plugin doesn't really define any property on Descriptor,
+    // you don't have to do this.
+    @SuppressWarnings("unchecked")
+    @Override
+    public BuildStepDescriptor getDescriptor() {
+        return (LambdaPublishBuildStep.DescriptorImpl)super.getDescriptor();
+    }
+
+    @Extension // This indicates to Jenkins that this is an implementation of an extension point.
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        public DescriptorImpl() {
+            load();
+        }
+
+        @SuppressWarnings("rawtypes")
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            // Indicates that this builder can be used with all kinds of project types
+            return true;
+        }
+
+        /**
+         * This human readable name is used in the configuration screen.
+         */
+        public String getDisplayName() {
+            return "AWS Lambda publish new version and update alias";
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            req.bindJSON(this, formData);
+
+            save();
+
+            return super.configure(req,formData);
+        }
+    }
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStepVariables.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStepVariables.java
@@ -1,0 +1,135 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.xti.jenkins.plugin.awslambda.AWSLambdaDescriptor;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Project: aws-lambda
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class LambdaPublishBuildStepVariables extends AbstractDescribableImpl<LambdaPublishBuildStepVariables> {
+
+    private boolean useInstanceCredentials;
+
+    private String awsRegion;
+    private String functionARN;
+    private String functionAlias;
+    private String awsAccessKeyId;
+    private String awsSecretKey;
+    private String clearTextAwsSecretKey;
+    private String versionDescription;
+
+    @DataBoundConstructor
+    public LambdaPublishBuildStepVariables(String awsRegion, String functionARN, String functionAlias, String versionDescription){
+        this.awsRegion = awsRegion;
+        this.functionARN = functionARN;
+        this.functionAlias = functionAlias;
+        this.versionDescription = versionDescription;
+    }
+
+    @Deprecated
+    public LambdaPublishBuildStepVariables(boolean useInstanceCredentials, String awsAccessKeyId, Secret awsSecretKey, String awsRegion, String functionARN, String functionAlias, String versionDescription) {
+        this.useInstanceCredentials = useInstanceCredentials;
+        this.awsAccessKeyId = awsAccessKeyId;
+        this.awsSecretKey = awsSecretKey != null ? awsSecretKey.getEncryptedValue() : null;
+        this.awsRegion = awsRegion;
+        this.functionARN = functionARN;
+        this.functionAlias = functionAlias;
+        this.versionDescription = versionDescription;
+    }
+
+    @DataBoundSetter
+    public void setUseInstanceCredentials(boolean useInstanceCredentials){
+        this.useInstanceCredentials = useInstanceCredentials;
+    }
+
+    public boolean getUseInstanceCredentials() {
+        return useInstanceCredentials;
+    }
+
+    @DataBoundSetter
+    public void setAwsAccessKeyId(String awsAccessKeyId) {
+        this.awsAccessKeyId = awsAccessKeyId;
+    }
+
+    public String getAwsAccessKeyId() {
+        return this.awsAccessKeyId;
+    }
+
+    @DataBoundSetter
+    public void setAwsSecretKey(String awsSecretKey) {
+        this.awsSecretKey = Secret.fromString(awsSecretKey).getEncryptedValue();
+    }
+
+    public String getAwsSecretKey() {
+        return this.awsSecretKey;
+    }
+
+    public String getAwsRegion() {
+        return this.awsRegion;
+    }
+
+    public String getFunctionARN() {
+        return this.functionARN;
+    }
+
+    public String getFunctionAlias() {
+        return this.functionAlias;
+    }
+
+    public String getVersionDescription() {
+        return this.versionDescription;
+    }
+
+    public void setVersionDescription(String versionDescription){
+        this.versionDescription = versionDescription;
+    }
+
+    public PublishConfig getPublishConfig() {
+        return new PublishConfig(this.functionAlias, this.functionARN, this.versionDescription);
+    }
+
+    public LambdaClientConfig getLambdaClientConfig(){
+        if(useInstanceCredentials){
+            return new LambdaClientConfig(awsRegion);
+        } else {
+            return new LambdaClientConfig(awsAccessKeyId, clearTextAwsSecretKey, awsRegion);
+        }
+    }
+
+    public void expandVariables(EnvVars env) {
+        awsAccessKeyId = expand(awsAccessKeyId, env);
+        clearTextAwsSecretKey = expand(Secret.toString(Secret.fromString(this.awsSecretKey)), env);
+        awsRegion = expand(this.awsRegion, env);
+        functionARN = expand(this.functionARN, env);
+        functionAlias = expand(this.functionAlias, env);
+        versionDescription = expand(this.versionDescription, env);
+    }
+
+    public LambdaPublishBuildStepVariables getClone(){
+        LambdaPublishBuildStepVariables lambdaPublishBuildStepVariables = new LambdaPublishBuildStepVariables(this.awsRegion, this.functionARN, this.functionAlias, this.versionDescription);
+        lambdaPublishBuildStepVariables.setAwsAccessKeyId(this.awsAccessKeyId);
+        lambdaPublishBuildStepVariables.setAwsSecretKey(this.awsSecretKey);
+        lambdaPublishBuildStepVariables.setUseInstanceCredentials(this.useInstanceCredentials);
+        return lambdaPublishBuildStepVariables;
+    }
+
+    private String expand(String value, EnvVars env) {
+        return Util.replaceMacro(value.trim(), env);
+    }
+
+    @Extension // This indicates to Jenkins that this is an implementation of an extension point.
+    public static class DescriptorImpl extends AWSLambdaDescriptor<LambdaPublishBuildStepVariables> {
+        public String getDisplayName() {
+            return "AWS Lambda publish new version and update alias";
+        }
+    }
+
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishPublisher.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishPublisher.java
@@ -1,0 +1,110 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.xti.jenkins.plugin.awslambda.publish.LambdaPublishServiceResponse;
+import com.xti.jenkins.plugin.awslambda.callable.PublishCallable;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.*;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Project: aws-lambda
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class LambdaPublishPublisher extends Notifier {
+
+    List<LambdaPublishVariables> lambdaPublishVariablesList = new ArrayList<>();
+
+    @DataBoundConstructor
+    public LambdaPublishPublisher(List<LambdaPublishVariables> lambdaPublishVariablesList) {
+        this.lambdaPublishVariablesList = lambdaPublishVariablesList;
+    }
+
+    public List<LambdaPublishVariables> getLambdaPublishVariablesList() {
+        return lambdaPublishVariablesList;
+    }
+
+    public void setLambdaPublishVariablesList(List<LambdaPublishVariables> lambdaPublishVariablesList) {
+        this.lambdaPublishVariablesList = lambdaPublishVariablesList;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+        boolean returnValue = true;
+
+        if(lambdaPublishVariablesList != null) {
+            for(LambdaPublishVariables variables : lambdaPublishVariablesList) {
+                returnValue = returnValue && perform(variables, build, launcher, listener);
+            }
+        }
+        return returnValue;
+    }
+
+    public boolean perform(LambdaPublishVariables variables, AbstractBuild<?, ?> build, Launcher launcher,
+                           BuildListener listener) {
+        try {
+            LambdaPublishVariables executionVariables = variables.getClone();
+            executionVariables.expandVariables(build.getEnvironment(listener));
+            PublishConfig publishConfig = executionVariables.getPublishConfig();
+            LambdaClientConfig clientConfig = executionVariables.getLambdaClientConfig();
+
+            PublishCallable publishCallable = new PublishCallable(listener, publishConfig, clientConfig);
+
+            LambdaPublishServiceResponse lambdaRepsonse = launcher.getChannel().call(publishCallable);
+
+            if(!lambdaRepsonse.getSuccess()){
+                build.setResult(Result.FAILURE);
+            }
+
+            build.addAction(new LambdaPublishAction(lambdaRepsonse.getFunctionVersion(), lambdaRepsonse.getFunctionAlias(), lambdaRepsonse.getSuccess()));
+            return true;
+        } catch (Exception exc) {
+            throw new RuntimeException(exc);
+        }
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.BUILD;
+    }
+
+    @Override
+    public BuildStepDescriptor getDescriptor() {
+        return (LambdaPublishPublisher.DescriptorImpl)super.getDescriptor();
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        public DescriptorImpl() {
+            load();
+        }
+
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
+
+        public String getDisplayName() {
+            return "AWS Lambda publish new version and update alias";
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            req.bindJSON(this, formData);
+
+            save();
+
+            return super.configure(req,formData);
+        }
+    }
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishServiceResponse.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishServiceResponse.java
@@ -1,0 +1,28 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+/**
+ * Created by sulland on 27/07/16.
+ */
+public class LambdaPublishServiceResponse {
+    private String functionVersion;
+    private String functionAlias;
+    private boolean success;
+
+    public LambdaPublishServiceResponse(String functionVersion, String functionAlias, boolean success){
+        this.functionAlias = functionAlias;
+        this.functionVersion = functionVersion;
+        this.success = success;
+    }
+
+    public String getFunctionVersion(){
+        return this.functionVersion;
+    }
+
+    public String getFunctionAlias(){
+        return this.functionAlias;
+    }
+
+    public boolean getSuccess(){
+        return this.success;
+    }
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishVariables.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishVariables.java
@@ -1,0 +1,148 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.xti.jenkins.plugin.awslambda.AWSLambdaDescriptor;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class LambdaPublishVariables  extends AbstractDescribableImpl<LambdaPublishVariables> {
+
+    private boolean useInstanceCredentials;
+
+    private String awsRegion;
+    private String functionARN;
+    private String functionAlias;
+    private String awsAccessKeyId;
+    private String awsSecretKey;
+    private String clearTextAwsSecretKey;
+    private String versionDescription;
+
+    @DataBoundConstructor
+    public LambdaPublishVariables(String awsRegion, String functionARN, String functionAlias, String versionDescription){
+        this.awsRegion = awsRegion;
+        this.functionARN = functionARN;
+        this.functionAlias = functionAlias;
+        this.versionDescription = versionDescription;
+    }
+
+    @Deprecated
+    public LambdaPublishVariables(boolean useInstanceCredentials, String awsAccessKeyId, Secret awsSecretKey, String awsRegion, String functionARN, String functionAlias, String versionDescription
+    ) {
+        this.useInstanceCredentials = useInstanceCredentials;
+        this.awsAccessKeyId = awsAccessKeyId;
+        this.awsSecretKey = awsSecretKey != null ? awsSecretKey.getEncryptedValue() : null;
+        this.awsRegion = awsRegion;
+        this.functionARN = functionARN;
+        this.functionAlias = functionAlias;
+        this.versionDescription = versionDescription;
+    }
+
+    public boolean getUseInstanceCredentials() {
+        return useInstanceCredentials;
+    }
+
+    public void setUseInstanceCredentials(boolean useInstanceCredentials){
+        this.useInstanceCredentials = useInstanceCredentials;
+    }
+
+    public String getAwsAccessKeyId() {
+        return this.awsAccessKeyId;
+    }
+
+    @DataBoundSetter
+    public void setAwsAccessKeyId(String awsAccessKeyId) {
+        this.awsAccessKeyId = awsAccessKeyId;
+    }
+
+    public String getAwsSecretKey() {
+        return this.awsSecretKey;
+    }
+
+    @DataBoundSetter
+    public void setAwsSecretKey(String awsSecretKey) {
+        this.awsSecretKey = Secret.fromString(awsSecretKey).getEncryptedValue();
+    }
+
+    public String getAwsRegion() {
+        return this.awsRegion;
+    }
+
+    @DataBoundSetter
+    public void setFunctionARN(String functionARN){
+        this.functionARN = functionARN;
+    }
+
+    public String getFunctionARN() {
+        return this.functionARN;
+    }
+
+    @DataBoundSetter
+    public void setFunctionAlias(String functionAlias){
+        this.functionAlias = functionAlias;
+    }
+
+    public String getFunctionAlias() {
+        return this.functionAlias;
+    }
+
+    public void setVersionDescription(String versionDescription){
+        this.versionDescription = versionDescription;
+    }
+
+    public String getVersionDescription(){
+        return this.versionDescription;
+    }
+
+    public PublishConfig getPublishConfig() {
+        return new PublishConfig(this.functionAlias, this.functionARN, this.versionDescription);
+    }
+
+    public LambdaClientConfig getLambdaClientConfig(){
+        if(useInstanceCredentials){
+            return new LambdaClientConfig(awsRegion);
+        } else {
+            return new LambdaClientConfig(awsAccessKeyId, clearTextAwsSecretKey, awsRegion);
+        }
+    }
+
+    public void expandVariables(EnvVars env) {
+        awsAccessKeyId = expand(awsAccessKeyId, env);
+        clearTextAwsSecretKey = expand(Secret.toString(Secret.fromString(this.awsSecretKey)), env);
+        awsRegion = expand(this.awsRegion, env);
+        functionARN = expand(this.functionARN, env);
+        functionAlias = expand(this.functionAlias, env);
+        versionDescription = expand(this.versionDescription, env);
+    }
+
+    private String expand(String value, EnvVars env) {
+        return Util.replaceMacro(value.trim(), env);
+    }
+
+    public LambdaPublishVariables getClone(){
+        LambdaPublishVariables lambdaPublishVariables = new LambdaPublishVariables(this.awsRegion, this.functionARN, this.functionAlias, this.versionDescription);
+        lambdaPublishVariables.setAwsAccessKeyId(this.awsAccessKeyId);
+        lambdaPublishVariables.setAwsSecretKey(this.awsSecretKey);
+        lambdaPublishVariables.setUseInstanceCredentials(this.useInstanceCredentials);
+        return lambdaPublishVariables;
+    }
+
+    @Extension // This indicates to Jenkins that this is an implementation of an extension point.
+    public static class DescriptorImpl extends AWSLambdaDescriptor<LambdaPublishVariables> {
+
+        /**
+         * This human readable name is used in the configuration screen.
+         */
+        public String getDisplayName() {
+            return "Lambda publish and change alias";
+        }
+
+    }
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublisher.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublisher.java
@@ -1,0 +1,32 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.xti.jenkins.plugin.awslambda.service.JenkinsLogger;
+import com.xti.jenkins.plugin.awslambda.service.LambdaPublishService;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+
+import java.io.IOException;
+
+/**
+ * Project: aws-lambda
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class LambdaPublisher extends Notifier {
+    private LambdaPublishService lambda;
+    private JenkinsLogger logger;
+
+    public LambdaPublisher(LambdaPublishService lambda, JenkinsLogger logger) throws IOException, InterruptedException {
+        this.lambda = lambda;
+        this.logger = logger;
+    }
+
+    public LambdaPublishServiceResponse publish(PublishConfig config) throws IOException, InterruptedException {
+        logger.log("%nStarting lambda publish procedure");
+        return lambda.publishLambda(config);
+    }
+
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.BUILD;
+    }
+
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/PublishConfig.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/PublishConfig.java
@@ -1,0 +1,41 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+/**
+ * Project: aws-lambda
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class PublishConfig {
+    private String functionAlias;
+    private String functionARN;
+    private String versionDescription;
+
+    public PublishConfig(String functionAlias, String functionARN, String versionDescription){
+        this.functionAlias = functionAlias;
+        this.functionARN = functionARN;
+        this.versionDescription = versionDescription;
+    }
+
+    public void setFunctionAlias(String alias) {
+        this.functionAlias = alias;
+    }
+
+    public String getFunctionAlias(){
+        return this.functionAlias;
+    }
+
+    public void setFunctionARN(String functionARN){
+        this.functionARN = functionARN;
+    }
+
+    public String getFunctionARN(){
+        return this.functionARN;
+    }
+
+    public String getVersionDescription() {
+        return this.versionDescription;
+    }
+
+    public void setVersionDescription(String versionDescription){
+        this.versionDescription = versionDescription;
+    }
+}

--- a/src/main/java/com/xti/jenkins/plugin/awslambda/service/LambdaPublishService.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/service/LambdaPublishService.java
@@ -1,0 +1,56 @@
+package com.xti.jenkins.plugin.awslambda.service;
+
+import com.amazonaws.services.lambda.AWSLambdaClient;
+import com.amazonaws.services.lambda.model.*;
+import com.xti.jenkins.plugin.awslambda.publish.LambdaPublishServiceResponse;
+import com.xti.jenkins.plugin.awslambda.publish.PublishConfig;
+
+/**
+ * Project: aws-lambda
+ * Created by Magnus Sulland on 26/07/2016.
+ */
+public class LambdaPublishService {
+    private AWSLambdaClient client;
+    private JenkinsLogger logger;
+
+    public LambdaPublishService(AWSLambdaClient client, JenkinsLogger logger) {
+        this.client = client;
+        this.logger = logger;
+    }
+
+    public LambdaPublishServiceResponse publishLambda(PublishConfig config){
+
+        GetAliasRequest getAliasRequest = new GetAliasRequest()
+                .withName(config.getFunctionAlias())
+                .withFunctionName(config.getFunctionARN());
+
+        logger.log("Lambda function alias existence check:%n%s%n%s%n", config.getFunctionARN(), config.getFunctionAlias());
+        try {
+            GetAliasResult functionResult = client.getAlias(getAliasRequest);
+            logger.log("Lambda function alias exists:%n%s%n", functionResult.toString());
+        } catch (ResourceNotFoundException rnfe) {
+            return new LambdaPublishServiceResponse("", "", false);
+        }
+
+        logger.log("Publishing new version");
+
+        PublishVersionRequest publishVersionRequest = new PublishVersionRequest().withFunctionName(config.getFunctionARN()).withDescription(config.getVersionDescription());
+        PublishVersionResult publishVersionResult = client.publishVersion(publishVersionRequest);
+
+        logger.log(publishVersionResult.toString());
+
+        logger.log("Updating alias");
+
+        UpdateAliasRequest updateAliasRequest = new UpdateAliasRequest().withName(config.getFunctionAlias());
+        updateAliasRequest.setFunctionName(config.getFunctionARN());
+        updateAliasRequest.setDescription(config.getVersionDescription());
+        updateAliasRequest.setFunctionVersion(publishVersionResult.getVersion());
+
+        UpdateAliasResult updateAliasResult = client.updateAlias(updateAliasRequest);
+
+        logger.log(updateAliasResult.toString());
+
+        return new LambdaPublishServiceResponse(publishVersionResult.getVersion(), updateAliasResult.getName(), true);
+    }
+
+}

--- a/src/main/resources/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishAction/summary.jelly
+++ b/src/main/resources/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishAction/summary.jelly
@@ -1,0 +1,6 @@
+<j:jelly xmlns:j="jelly:core"
+         xmlns:t="/lib/hudson">
+    <t:summary icon="${it.bigIconFileName}">
+        <a href="${it.urlName}" target="_blank">${it.displayName}</a>
+    </t:summary>
+</j:jelly>

--- a/src/main/resources/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStep/config.jelly
+++ b/src/main/resources/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStep/config.jelly
@@ -1,0 +1,26 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry>
+        <f:property field="lambdaPublishBuildStepVariables">
+        <table width="100%">
+            <f:entry title="AWS Access Key Id" field="awsAccessKeyId" help="/plugin/aws-lambda/help-awsAccessKeyId.html">
+                <f:textbox />
+            </f:entry>
+            <f:entry title="AWS Secret Key" field="awsSecretKey" help="/plugin/aws-lambda/help-awsSecretKey.html">
+                <f:password />
+            </f:entry>
+            <f:entry title="AWS Region" field="awsRegion" help="/plugin/aws-lambda/help-awsRegion.html">
+                <f:textbox />
+            </f:entry>
+            <f:entry title="Function ARN" field="functionARN" help="/plugin/aws-lambda/help-functionARN.html">
+                <f:textbox />
+            </f:entry>
+            <f:entry title="Function Alias" field="functionAlias" help="/plugin/aws-lambda/help-alias.html">
+                <f:textbox />
+            </f:entry>
+            <f:entry field="versionDescription" title="Version Description" help="/plugin/aws-lambda/help-versionDescription.html">
+                <f:textbox />
+            </f:entry>
+        </table>
+        </f:property>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStepVariables/config.jelly
+++ b/src/main/resources/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStepVariables/config.jelly
@@ -1,0 +1,30 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:awslambda="/com/xti/jenkins/plugin/awslambda/tags">
+    <f:entry title="Publish new lambda version and update alias">
+        <f:nested>
+            <div style="padding-left:1em">
+                <table width="100%">
+                    <awslambda:awsLambdaOptionalBlock field="useInstanceCredentials" title="Use instance credentials" negative="true" checked="${instance.useInstanceCredentials}" default="false" inline="true" help="/plugin/aws-lambda/help-useInstanceCredentials.html">
+                        <f:entry title="AWS Access Key Id" field="awsAccessKeyId"  help="/plugin/aws-lambda/help-awsAccessKeyId.html">
+                            <f:textbox />
+                        </f:entry>
+                        <f:entry title="AWS Secret Key" field="awsSecretKey" help="/plugin/aws-lambda/help-awsSecretKey.html">
+                            <f:password />
+                        </f:entry>
+                    </awslambda:awsLambdaOptionalBlock>
+                    <f:entry title="AWS Region" help="/plugin/aws-lambda/help-awsRegion.html">
+                        <f:textbox name="awsRegion" field="awsRegion" />
+                    </f:entry>
+                    <f:entry title="Function ARN" help="/plugin/aws-lambda/help-functionARN.html">
+                        <f:textbox name="functionARN" field="functionARN" />
+                    </f:entry>
+                    <f:entry title="Function Alias" help="/plugin/aws-lambda/help-alias.html">
+                        <f:textbox name="functionAlias" field="functionAlias" />
+                    </f:entry>
+                    <f:entry field="versionDescription" title="Version Description" help="/plugin/aws-lambda/help-versionDescription.html">
+                        <f:textbox />
+                    </f:entry>
+                </table>
+            </div>
+        </f:nested>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishPublisher/config.jelly
+++ b/src/main/resources/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishPublisher/config.jelly
@@ -1,0 +1,28 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:awslambda="/com/xti/jenkins/plugin/awslambda/tags">
+    <f:entry title="Publish new lambda version and update alias">
+        <f:repeatable field="lambdaPublishVariablesList" header="Lambda publish" add="Publish new lambda version and update alias">
+            <table width="100%">
+                <awslambda:awsLambdaOptionalBlock field="useInstanceCredentials" title="Use instance credentials" negative="true" checked="${instance.useInstanceCredentials}" default="false" inline="true" help="/plugin/aws-lambda/help-useInstanceCredentials.html">
+                    <f:entry title="AWS Access Key Id" field="awsAccessKeyId"  help="/plugin/aws-lambda/help-awsAccessKeyId.html">
+                        <f:textbox />
+                    </f:entry>
+                    <f:entry title="AWS Secret Key" field="awsSecretKey" help="/plugin/aws-lambda/help-awsSecretKey.html">
+                        <f:password />
+                    </f:entry>
+                </awslambda:awsLambdaOptionalBlock>
+                <f:entry field="awsRegion" title="AWS Region" help="/plugin/aws-lambda/help-awsRegion.html">
+                    <f:textbox />
+                </f:entry>
+                <f:entry field="functionARN" title="Function ARN" help="/plugin/aws-lambda/help-functionARN.html">
+                    <f:textbox />
+                </f:entry>
+                <f:entry field="functionAlias" title="Function Alias" help="/plugin/aws-lambda/help-alias.html">
+                    <f:textbox />
+                </f:entry>
+                <f:entry field="versionDescription" title="Version Description" help="/plugin/aws-lambda/help-versionDescription.html">
+                    <f:textbox />
+                </f:entry>
+            </table>
+        </f:repeatable>
+    </f:entry>
+</j:jelly>

--- a/src/main/webapp/help-alias.html
+++ b/src/main/webapp/help-alias.html
@@ -1,0 +1,28 @@
+<!--
+  #%L
+  AWS Lambda Upload Plugin
+  %%
+  Copyright (C) 2016 Magnus Sulland
+  %%
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  #L%
+  -->
+<div>
+    Name of the alias to be pointing to the new function version.
+</div>

--- a/src/main/webapp/help-functionARN.html
+++ b/src/main/webapp/help-functionARN.html
@@ -1,0 +1,28 @@
+<!--
+  #%L
+  AWS Lambda Upload Plugin
+  %%
+  Copyright (C) 2016 Magnus Sulland
+  %%
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  #L%
+  -->
+<div>
+    ARN to the lambda function the alias should point to the $LATEST version of.
+</div>

--- a/src/main/webapp/help-versionDescription.html
+++ b/src/main/webapp/help-versionDescription.html
@@ -1,0 +1,28 @@
+<!--
+  #%L
+  AWS Lambda Upload Plugin
+  %%
+  Copyright (C) 2016 Magnus Sulland
+  %%
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  #L%
+  -->
+<div>
+    A description to be given to the version. Recommended is the build number and information from jenkins.
+</div>

--- a/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishActionTest.java
+++ b/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishActionTest.java
@@ -1,0 +1,33 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Magnus Sulland on 4/08/2016.
+ */
+
+public class LambdaPublishActionTest {
+
+    @Test
+    public void testLambdaUploadActionSuccess(){
+        LambdaPublishAction lambdaUploadAction = new LambdaPublishAction("42", "alias1", true);
+
+        assertEquals("Lambda alias alias1 points to version 42", lambdaUploadAction.getDisplayName());
+        assertEquals("console", lambdaUploadAction.getUrlName());
+        assertEquals("/plugin/aws-lambda/images/Lambda_24.png", lambdaUploadAction.getIconFileName());
+        assertEquals("/plugin/aws-lambda/images/Lambda_48.png", lambdaUploadAction.getBigIconFileName());
+    }
+
+    @Test
+    public void testLambdaUploadActionFailure(){
+        LambdaPublishAction lambdaUploadAction = new LambdaPublishAction("42", "alias1", false);
+
+        assertEquals("Unable to point alias alias1 to version 42", lambdaUploadAction.getDisplayName());
+        assertEquals("console", lambdaUploadAction.getUrlName());
+        assertEquals("/plugin/aws-lambda/images/Lambda_24_grey.png", lambdaUploadAction.getIconFileName());
+        assertEquals("/plugin/aws-lambda/images/Lambda_48_grey.png", lambdaUploadAction.getBigIconFileName());
+    }
+
+}

--- a/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStepTest.java
+++ b/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStepTest.java
@@ -1,0 +1,126 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.amazonaws.services.lambda.AWSLambdaClient;
+import com.amazonaws.services.lambda.model.*;
+import com.xti.jenkins.plugin.awslambda.invoke.LambdaInvokeBuildStepTest;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.EnvVars;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.util.LogTaskListener;
+import hudson.util.Secret;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.any;
+
+/**
+ * Created by Magnus Sulland on 4/08/2016.
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class LambdaPublishBuildStepTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Mock
+    private LambdaPublishBuildStepVariables original;
+
+    @Mock
+    private LambdaClientConfig clientConfig;
+
+    @Mock
+    private AWSLambdaClient lambdaClient;
+
+    @Test
+    public void testPerform() throws IOException, ExecutionException, InterruptedException {
+        LambdaPublishBuildStepVariables clone = new LambdaPublishBuildStepVariables(false, "${ENV_ID}", Secret.fromString("$ENV_SECRET}}"), "${ENV_REGION}", "${ENV_ARN}", "${ENV_ALIAS}", "description ${ENV_VERSIONDESCRIPTION}");
+        LambdaPublishBuildStepVariables spy = Mockito.spy(clone);
+
+        when(original.getClone()).thenReturn(spy);
+        when(spy.getLambdaClientConfig()).thenReturn(clientConfig);
+        when(clientConfig.getClient()).thenReturn(lambdaClient);
+
+        PublishVersionResult publishResult = new PublishVersionResult()
+                .withFunctionArn("ARN")
+                .withDescription("DESCRIPTION")
+                .withVersion("VERSION");
+
+        when(lambdaClient.publishVersion(any(PublishVersionRequest.class)))
+                .thenReturn(publishResult);
+
+        UpdateAliasResult aliasResult = new UpdateAliasResult()
+                .withDescription("DESCRIPTION")
+                .withFunctionVersion("VERSION")
+                .withName("ALIAS");
+
+        when(lambdaClient.updateAlias(any(UpdateAliasRequest.class)))
+                .thenReturn(aliasResult);
+
+        GetAliasResult aliasFindResult = new GetAliasResult();
+
+        when(lambdaClient.getAlias(any(GetAliasRequest.class)))
+                .thenReturn(aliasFindResult);
+
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new LambdaPublishBuildStep(original));
+
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+    }
+
+
+    @Test
+    public void testPerformFailure() throws IOException, ExecutionException, InterruptedException {
+        LambdaPublishBuildStepVariables clone = new LambdaPublishBuildStepVariables(false, "${ENV_ID}", Secret.fromString("$ENV_SECRET}}"), "${ENV_REGION}", "${ENV_ARN}", "${ENV_ALIAS}", "description ${ENV_VERSIONDESCRIPTION}");
+        LambdaPublishBuildStepVariables spy = Mockito.spy(clone);
+
+        when(original.getClone()).thenReturn(spy);
+        when(spy.getLambdaClientConfig()).thenReturn(clientConfig);
+        when(clientConfig.getClient()).thenReturn(lambdaClient);
+
+        PublishVersionResult publishResult = new PublishVersionResult()
+                .withFunctionArn("ARN")
+                .withDescription("DESCRIPTION")
+                .withVersion("VERSION");
+
+        when(lambdaClient.publishVersion(any(PublishVersionRequest.class)))
+                .thenReturn(publishResult);
+
+        UpdateAliasResult aliasResult = new UpdateAliasResult()
+                .withDescription("DESCRIPTION")
+                .withFunctionVersion("VERSION")
+                .withName("ALIAS");
+
+        when(lambdaClient.updateAlias(any(UpdateAliasRequest.class)))
+                .thenReturn(aliasResult);
+
+        GetAliasResult aliasFindResult = new GetAliasResult();
+
+        when(lambdaClient.getAlias(any(GetAliasRequest.class)))
+                .thenThrow(new ResourceNotFoundException(""));
+
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new LambdaPublishBuildStep(original));
+
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        assertEquals(Result.FAILURE, build.getResult());
+    }
+}

--- a/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStepVariablesTest.java
+++ b/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishBuildStepVariablesTest.java
@@ -1,0 +1,66 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.EnvVars;
+import hudson.util.Secret;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by Magnus Sulland on 4/08/2016.
+ */
+
+public class LambdaPublishBuildStepVariablesTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testCloneExpandVariables() throws Exception {
+        LambdaPublishBuildStepVariables variables = new LambdaPublishBuildStepVariables(false, "${ENV_ID}", Secret.fromString("$ENV_SECRET}}"), "${ENV_REGION}", "${ENV_ARN}", "${ENV_ALIAS}", "description ${ENV_VERSIONDESCRIPTION}");
+        LambdaPublishBuildStepVariables clone = variables.getClone();
+
+        EnvVars envVars = new EnvVars();
+        envVars.put("ENV_ID", "ID");
+        envVars.put("ENV_SECRET", "SECRET");
+        envVars.put("ENV_REGION", "eu-west-1");
+        envVars.put("ENV_ARN", "ARN");
+        envVars.put("ENV_ALIAS", "ALIAS");
+        envVars.put("ENV_VERSIONDESCRIPTION", "DESCRIPTION");
+        clone.expandVariables(envVars);
+
+        LambdaPublishBuildStepVariables expected = new LambdaPublishBuildStepVariables(false, "ID", Secret.fromString("$ENV_SECRET}}"), "eu-west-1", "ARN", "ALIAS", "description DESCRIPTION");
+
+        assertEquals(expected.getAwsAccessKeyId(), clone.getAwsAccessKeyId());
+        assertEquals(expected.getAwsSecretKey(), clone.getAwsSecretKey());
+        assertEquals(expected.getAwsRegion(), clone.getAwsRegion());
+        assertEquals(expected.getFunctionARN(), clone.getFunctionARN());
+        assertEquals(expected.getFunctionAlias(), clone.getFunctionAlias());
+        assertEquals(expected.getVersionDescription(), clone.getVersionDescription());
+    }
+
+    @Test
+    public void testGetPublishConfig() throws Exception {
+        LambdaPublishBuildStepVariables variables = new LambdaPublishBuildStepVariables(false, "ID", Secret.fromString("SECRET}"), "eu-west-1", "ARN", "ALIAS", "DESCRIPTION");
+        PublishConfig publishConfig = variables.getPublishConfig();
+
+        assertEquals(variables.getFunctionARN(), publishConfig.getFunctionARN());
+        assertEquals(variables.getVersionDescription(), publishConfig.getVersionDescription());
+        assertEquals(variables.getFunctionAlias(), publishConfig.getFunctionAlias());
+    }
+
+    @Test
+    public void testGetLambdaClientConfig() throws Exception {
+        LambdaPublishBuildStepVariables variables = new LambdaPublishBuildStepVariables(false, "ID", Secret.fromString("SECRET}"), "eu-west-1", "ARN", "ALIAS", "DESCRIPTION");
+        variables.expandVariables(new EnvVars());
+        LambdaClientConfig lambdaClientConfig = variables.getLambdaClientConfig();
+
+        AWSLambda lambda = lambdaClientConfig.getClient();
+        assertNotNull(lambda);
+    }
+}

--- a/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishPublisherTest.java
+++ b/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishPublisherTest.java
@@ -1,0 +1,124 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.amazonaws.services.lambda.AWSLambdaClient;
+import com.amazonaws.services.lambda.model.*;
+import com.xti.jenkins.plugin.awslambda.invoke.LambdaInvokePublisher;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.EnvVars;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.util.LogTaskListener;
+import hudson.util.Secret;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by Magnus Sulland on 4/08/2016.
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class LambdaPublishPublisherTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Mock
+    private LambdaPublishVariables original;
+
+    @Mock
+    private LambdaClientConfig clientConfig;
+
+    @Mock
+    private AWSLambdaClient lambdaClient;
+
+    @Test
+    public void testPerform() throws IOException, ExecutionException, InterruptedException {
+        LambdaPublishVariables clone = new LambdaPublishVariables(false, "${ENV_ID}", Secret.fromString("$ENV_SECRET}}"), "${ENV_REGION}", "${ENV_ARN}", "${ENV_ALIAS}", "description ${ENV_VERSIONDESCRIPTION}");
+        LambdaPublishVariables spy = Mockito.spy(clone);
+
+        when(original.getClone()).thenReturn(spy);
+        when(spy.getLambdaClientConfig()).thenReturn(clientConfig);
+        when(clientConfig.getClient()).thenReturn(lambdaClient);
+
+        PublishVersionResult publishResult = new PublishVersionResult()
+                .withFunctionArn("ARN")
+                .withDescription("DESCRIPTION")
+                .withVersion("VERSION");
+
+        when(lambdaClient.publishVersion(any(PublishVersionRequest.class)))
+                .thenReturn(publishResult);
+
+        UpdateAliasResult aliasResult = new UpdateAliasResult()
+                .withDescription("DESCRIPTION")
+                .withFunctionVersion("VERSION")
+                .withName("ALIAS");
+
+        when(lambdaClient.updateAlias(any(UpdateAliasRequest.class)))
+                .thenReturn(aliasResult);
+
+        GetAliasResult aliasFindResult = new GetAliasResult();
+
+        when(lambdaClient.getAlias(any(GetAliasRequest.class)))
+                .thenReturn(aliasFindResult);
+
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getPublishersList().add(new LambdaPublishPublisher(Arrays.asList(original, original)));
+
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+    }
+
+
+    @Test
+    public void testPerformFailure() throws IOException, ExecutionException, InterruptedException {
+        LambdaPublishVariables clone = new LambdaPublishVariables(false, "${ENV_ID}", Secret.fromString("$ENV_SECRET}}"), "${ENV_REGION}", "${ENV_ARN}", "${ENV_ALIAS}", "description ${ENV_VERSIONDESCRIPTION}");
+        LambdaPublishVariables spy = Mockito.spy(clone);
+
+        when(original.getClone()).thenReturn(spy);
+        when(spy.getLambdaClientConfig()).thenReturn(clientConfig);
+        when(clientConfig.getClient()).thenReturn(lambdaClient);
+
+        PublishVersionResult publishResult = new PublishVersionResult()
+                .withFunctionArn("ARN")
+                .withDescription("DESCRIPTION")
+                .withVersion("VERSION");
+
+        when(lambdaClient.publishVersion(any(PublishVersionRequest.class)))
+                .thenReturn(publishResult);
+
+        UpdateAliasResult aliasResult = new UpdateAliasResult()
+                .withDescription("DESCRIPTION")
+                .withFunctionVersion("VERSION")
+                .withName("ALIAS");
+
+        when(lambdaClient.updateAlias(any(UpdateAliasRequest.class)))
+                .thenReturn(aliasResult);
+
+        GetAliasResult aliasFindResult = new GetAliasResult();
+
+        when(lambdaClient.getAlias(any(GetAliasRequest.class)))
+                .thenThrow(new ResourceNotFoundException(""));
+
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getPublishersList().add(new LambdaPublishPublisher(Arrays.asList(original, original)));
+
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        assertEquals(Result.FAILURE, build.getResult());
+    }
+}

--- a/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishTest.java
+++ b/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishTest.java
@@ -1,0 +1,66 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.xti.jenkins.plugin.awslambda.service.JenkinsLogger;
+import com.xti.jenkins.plugin.awslambda.service.LambdaPublishService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by Magnus Sulland on 4/08/2016.
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class LambdaPublishTest {
+
+    @Mock
+    private LambdaPublishService service;
+
+    @Mock
+    private JenkinsLogger logger;
+
+    @Test
+    public void testPublishSuccess() throws Exception {
+        when(service.publishLambda(any(PublishConfig.class))).thenReturn(new LambdaPublishServiceResponse("VERSION", "ALIAS", true));
+
+        LambdaPublisher publisher = new LambdaPublisher(service, logger);
+
+        PublishConfig publishConfig = new PublishConfig("ALIAS", "ARN", "DESCRIPTION");
+
+        LambdaPublishServiceResponse result = publisher.publish(publishConfig);
+
+        verify(logger, times(1)).log("%nStarting lambda publish procedure");
+
+        assertEquals(publishConfig.getFunctionAlias(), result.getFunctionAlias());
+        assertEquals(result.getFunctionVersion(), "VERSION");
+
+        assertTrue(result.getSuccess());
+    }
+
+    @Test
+    public void testPublishFailure() throws Exception {
+        when(service.publishLambda(any(PublishConfig.class))).thenReturn(new LambdaPublishServiceResponse("VERSION", "ALIAS", false));
+
+        LambdaPublisher publisher = new LambdaPublisher(service, logger);
+
+        PublishConfig publishConfig = new PublishConfig("ALIAS", "ARN", "DESCRIPTION");
+
+        LambdaPublishServiceResponse result = publisher.publish(publishConfig);
+
+        verify(logger, times(1)).log("%nStarting lambda publish procedure");
+
+        assertEquals(publishConfig.getFunctionAlias(), result.getFunctionAlias());
+        assertEquals(result.getFunctionVersion(), "VERSION");
+
+        assertFalse(result.getSuccess());
+    }
+}

--- a/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishVariablesTest.java
+++ b/src/test/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishVariablesTest.java
@@ -1,0 +1,66 @@
+package com.xti.jenkins.plugin.awslambda.publish;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.xti.jenkins.plugin.awslambda.util.LambdaClientConfig;
+import hudson.EnvVars;
+import hudson.util.Secret;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by Magnus Sulland on 4/08/2016.
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class LambdaPublishVariablesTest {
+
+    @Test
+    public void testCloneExpandVariables() throws Exception {
+        LambdaPublishVariables variables = new LambdaPublishVariables(false, "${ENV_ID}", Secret.fromString("$ENV_SECRET}}"), "${ENV_REGION}", "${ENV_ARN}", "${ENV_ALIAS}", "description ${ENV_VERSIONDESCRIPTION}");
+        LambdaPublishVariables clone = variables.getClone();
+
+        EnvVars envVars = new EnvVars();
+        envVars.put("ENV_ID", "ID");
+        envVars.put("ENV_SECRET", "SECRET");
+        envVars.put("ENV_REGION", "eu-west-1");
+        envVars.put("ENV_ARN", "ARN");
+        envVars.put("ENV_ALIAS", "ALIAS");
+        envVars.put("ENV_VERSIONDESCRIPTION", "DESCRIPTION");
+        clone.expandVariables(envVars);
+
+        LambdaPublishVariables expected = new LambdaPublishVariables(false, "ID", Secret.fromString("$ENV_SECRET}}"), "eu-west-1", "ARN", "ALIAS", "description DESCRIPTION");
+
+        assertEquals(expected.getAwsAccessKeyId(), clone.getAwsAccessKeyId());
+        assertEquals(expected.getAwsSecretKey(), clone.getAwsSecretKey());
+        assertEquals(expected.getAwsRegion(), clone.getAwsRegion());
+        assertEquals(expected.getFunctionARN(), clone.getFunctionARN());
+        assertEquals(expected.getFunctionAlias(), clone.getFunctionAlias());
+        assertEquals(expected.getVersionDescription(), clone.getVersionDescription());
+    }
+
+    @Test
+    public void testGetPublishConfig() throws Exception {
+        LambdaPublishVariables variables = new LambdaPublishVariables("eu-west-1", "ARN", "ALIAS", "DESCRIPTION");
+        PublishConfig publishConfig = variables.getPublishConfig();
+
+        assertEquals(variables.getFunctionAlias(), publishConfig.getFunctionAlias());
+        assertEquals(variables.getFunctionARN(), publishConfig.getFunctionARN());
+        assertEquals(variables.getVersionDescription(), publishConfig.getVersionDescription());
+    }
+
+    @Test
+    public void testGetLambdaClientConfig() throws Exception {
+        LambdaPublishVariables variables = new LambdaPublishVariables(false, "KEY", Secret.fromString("SECRET}"), "eu-west-1", "ARN", "ALIAS", "DESCRIPTION");
+        variables.expandVariables(new EnvVars());
+        LambdaClientConfig lambdaClientConfig = variables.getLambdaClientConfig();
+
+        AWSLambda lambda = lambdaClientConfig.getClient();
+        assertNotNull(lambda);
+    }
+}


### PR DESCRIPTION
Hi,

I have created a new build step that makes it possible to verify your lambda before creating a new version and updating a alias to point to the new version.
<img width="337" alt="buildpage" src="https://cloud.githubusercontent.com/assets/1140156/17442708/4894cde4-5b37-11e6-9744-41a3dbb53101.png">

