### PR TITLE
update version of AWS sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 	</developers>
 
     <properties>
-        <aws.version>1.11.64</aws.version>
+        <aws.version>1.11.160</aws.version>
         <jsonpath.version>2.0.0</jsonpath.version>
     </properties>
 


### PR DESCRIPTION
As per https://github.com/XT-i/aws-lambda-jenkins-plugin/issues/76 the current aws sdk version doesn't support eu-west-2. This version should provide the necessary support