### PR TITLE
Fix: LambdaPublishServiceResponse is not serializable

### DIFF
--- a/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishServiceResponse.java
+++ b/src/main/java/com/xti/jenkins/plugin/awslambda/publish/LambdaPublishServiceResponse.java
@@ -1,9 +1,11 @@
 package com.xti.jenkins.plugin.awslambda.publish;
 
+import java.io.Serializable;
+
 /**
  * Created by sulland on 27/07/16.
  */
-public class LambdaPublishServiceResponse {
+public class LambdaPublishServiceResponse implements Serializable {
     private String functionVersion;
     private String functionAlias;
     private boolean success;


### PR DESCRIPTION
Fix for https://github.com/XT-i/aws-lambda-jenkins-plugin/issues/75